### PR TITLE
Fixed install script

### DIFF
--- a/ob.installer.sh
+++ b/ob.installer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2012-2013 OpenBroadcaster, Inc.
 


### PR DESCRIPTION
This script will not work under sh, but will under bash.

The original version didn't work on Debian 9.4, but switching from /bin/sh to /bin/bash worked.