### PR TITLE
Fixed typo in example code

### DIFF
--- a/docs/appkeys.html
+++ b/docs/appkeys.html
@@ -11,7 +11,7 @@ below:</p>
   'dataType': 'json',
   'data': {
     "c": "media",
-    "a": "media_search",
+    "a": "search",
     "d": JSON.stringify({
       "save_history": true,
       "sort_by": "updated",
@@ -36,7 +36,7 @@ installation.</p>
 $url = "https://openbroadcaster-server-location.com/api.php";
 $data = http_build_query([
   'c' => 'media',
-  'a' => 'media_search',
+  'a' => 'search',
   'd' => json_encode([
     'save_history' => true,
     'sort_by'      => 'updated',


### PR DESCRIPTION
The function being called is named 'search', not 'media_search'