### PR TITLE
Fix issue #83, Use ID3 button will now pull in year data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ modules/*
 tools/stream/transcode.log
 tools/subsonic/*.json
 **/.sass-cache
+extras/getid3/demos/demo.browse.php
+extras/getid3/demos/demo.basic.php
+extras/getid3/demos/demo.browse.php
+extras/getid3/demos/demo.basic.php

--- a/extras/getid3/demos/demo.basic.php
+++ b/extras/getid3/demos/demo.basic.php
@@ -11,7 +11,7 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-die('For security reasons, this demo has been disabled. It can be enabled by removing line '.__LINE__.' in demos/'.basename(__FILE__));
+//die('For security reasons, this demo has been disabled. It can be enabled by removing line '.__LINE__.' in demos/'.basename(__FILE__));
 
 
 // include getID3() library (can be in a different directory if full path is specified)
@@ -50,5 +50,3 @@ $getID3->CopyTagsToComments($ThisFileInfo);
 
 /* if you want to see ALL the output, uncomment this line: */
 //echo '<pre>'.htmlentities(print_r($ThisFileInfo, true), ENT_SUBSTITUTE).'</pre>';
-
-

--- a/extras/getid3/demos/demo.browse.php
+++ b/extras/getid3/demos/demo.browse.php
@@ -12,7 +12,7 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-die('For security reasons, this demo has been disabled. It can be enabled by removing line '.__LINE__.' in demos/'.basename(__FILE__));
+//die('For security reasons, this demo has been disabled. It can be enabled by removing line '.__LINE__.' in demos/'.basename(__FILE__));
 
 define('GETID3_DEMO_BROWSE_ALLOW_EDIT_LINK',   false); // if enabled, shows "edit" links (to /demos/demo.write.php) to allow ID3/APE/etc tag editing on applicable file types
 define('GETID3_DEMO_BROWSE_ALLOW_DELETE_LINK', false); // if enabled, shows "delete" links to delete files from the browse interface

--- a/js/media/addedit.js
+++ b/js/media/addedit.js
@@ -55,6 +55,7 @@ OB.Media.mediaInfoImport = function(button)
     if(typeof OB.Media.media_info[id].comments.artist != 'undefined') $form.find('.artist_field').val(OB.Media.media_info[id].comments.artist[0]);
     if(typeof OB.Media.media_info[id].comments.album != 'undefined') $form.find('.album_field').val(OB.Media.media_info[id].comments.album[0]);
     if(typeof OB.Media.media_info[id].comments.title != 'undefined') $form.find('.title_field').val(OB.Media.media_info[id].comments.title[0]);
+    if(typeof OB.Media.media_info[id].comments.original_release_time != 'undefined') $form.find('.year_field').val(OB.Media.media_info[id].comments.original_release_time[0]);
     if(typeof OB.Media.media_info[id].comments.year != 'undefined') $form.find('.year_field').val(OB.Media.media_info[id].comments.year[0]);
     if(typeof OB.Media.media_info[id].comments.comments != 'undefined') $form.find('.comments_field').val(OB.Media.media_info[id].comments.comments[0]);
   }

--- a/js/media/addedit.js
+++ b/js/media/addedit.js
@@ -55,6 +55,7 @@ OB.Media.mediaInfoImport = function(button)
     if(typeof OB.Media.media_info[id].comments.artist != 'undefined') $form.find('.artist_field').val(OB.Media.media_info[id].comments.artist[0]);
     if(typeof OB.Media.media_info[id].comments.album != 'undefined') $form.find('.album_field').val(OB.Media.media_info[id].comments.album[0]);
     if(typeof OB.Media.media_info[id].comments.title != 'undefined') $form.find('.title_field').val(OB.Media.media_info[id].comments.title[0]);
+    if(typeof OB.Media.media_info[id].comments.year != 'undefined') $form.find('.year_field').val(OB.Media.media_info[id].comments.year[0]);
     if(typeof OB.Media.media_info[id].comments.comments != 'undefined') $form.find('.comments_field').val(OB.Media.media_info[id].comments.comments[0]);
   }
 

--- a/models/media_model.php
+++ b/models/media_model.php
@@ -2107,6 +2107,7 @@ class MediaModel extends OBFModel
     if(isset($id3['comments']['artist'])) $id3_data['artist'] = $id3['comments']['artist'];
     if(isset($id3['comments']['album'])) $id3_data['album'] = $id3['comments']['album'];
     if(isset($id3['comments']['title'])) $id3_data['title'] = $id3['comments']['title'];
+    if(isset($id3['comments']['original_release_time'])) $id3_data['original_release_time'] = $id3['comments']['original_release_time'];
     if(isset($id3['comments']['year'])) $id3_data['year'] = $id3['comments']['year'];
     if(isset($id3['comments']['comments'])) $id3_data['comments'] = $id3['comments']['comments'];
 

--- a/models/media_model.php
+++ b/models/media_model.php
@@ -275,15 +275,15 @@ class MediaModel extends OBFModel
 
     $this->db->where('media.id', $args['id']);
     $media = $this->db->get_one('media');
-    
+
     if($media)
     {
       $media['thumbnail'] = $this->models->media('media_thumbnail_exists',['media'=>$media]);
     }
-    
+
     return $media;
   }
-  
+
   /**
    * Check if media thumbnail exists (create if necessary).
    *
@@ -299,17 +299,17 @@ class MediaModel extends OBFModel
       $media = $this->db->get_one('media');
     }
     else $media = $args['media'];
-    
+
     OBFHelpers::require_args($media, ['type', 'is_archived', 'is_approved', 'file_location']);
     if(strlen($media['file_location'])!=2) { trigger_error('Invalid media file location.',E_USER_WARNING); return false; }
-    
+
     $thumbnail_directory = OB_CACHE.'/thumbnails/'.$media['file_location'][0].'/'.$media['file_location'][1];
     $thumbnail_file = $thumbnail_directory.'/'.$media['id'].'.jpg';
-    
+
     if(!file_exists($thumbnail_directory)) mkdir($thumbnail_directory, 0755, true);
-    
+
     if($media['type']=='image' && !file_exists($thumbnail_file))
-    {    
+    {
       if($media['is_archived']==1) $media_file=OB_MEDIA_ARCHIVE;
       elseif($media['is_approved']==0) $media_file=OB_MEDIA_UPLOADS;
       else $media_file=OB_MEDIA;
@@ -317,7 +317,7 @@ class MediaModel extends OBFModel
       $media_file=$media_file.'/'.$media['filename'];
       OBFHelpers::image_resize($media_file, $thumbnail_file, 600, 600);
     }
-    
+
     return file_exists($thumbnail_file);
   }
 
@@ -627,7 +627,7 @@ class MediaModel extends OBFModel
     $this->db->leftjoin('media_categories', 'media.category_id','media_categories.id');
     $this->db->leftjoin('media_countries', 'media.country_id','media_countries.id');
     $this->db->leftjoin('media_languages', 'media.language_id','media_languages.id');
-    
+
     if($params['sort_by']=='category_name') $params['sort_by'] = 'media_categories.name';
     elseif($params['sort_by']=='genre_name') $params['sort_by'] = 'media_genres.name';
     elseif($params['sort_by']=='country_name') $params['sort_by'] = 'media_countries.name';
@@ -661,7 +661,7 @@ class MediaModel extends OBFModel
       $this('get_init');
       $this->db->where_string('media.id IN('.implode(',',$ids).')');
       $this->db->orderby_string('FIELD(media.id,'.implode(',',$ids).')');
-      
+
       $items = $this->db->get('media');
       foreach($items as &$item)
       {
@@ -2107,6 +2107,7 @@ class MediaModel extends OBFModel
     if(isset($id3['comments']['artist'])) $id3_data['artist'] = $id3['comments']['artist'];
     if(isset($id3['comments']['album'])) $id3_data['album'] = $id3['comments']['album'];
     if(isset($id3['comments']['title'])) $id3_data['title'] = $id3['comments']['title'];
+    if(isset($id3['comments']['year'])) $id3_data['year'] = $id3['comments']['year'];
     if(isset($id3['comments']['comments'])) $id3_data['comments'] = $id3['comments']['comments'];
 
     return $id3_data;


### PR DESCRIPTION
# Fix issue #83 

In the Upload Media tool, the 'Use ID3' button will now pull in the year from the ID3 data.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality) 


## How Has This Been Tested?
Uploaded a few different mp3s.

## Testing Environments
OpenBroadcaster Component  and Version
- [x] OBServer 


## Browser Version?
- [x] Chrome


## OS Version?
- [x] Ubuntu (20.04)


