### PR TITLE
feat(search): Add "dynamic_select" filter to advanced search and media model.

### DIFF
--- a/classes/models/media_model.php
+++ b/classes/models/media_model.php
@@ -952,7 +952,7 @@ class MediaModel extends OBFModel
         OBFHelpers::require_args($args, ['filters']);
         $filters = $args['filters'];
 
-        $allowed_filters = ['comments','artist','title','album','year','type','category','country','language','genre','duration','is_copyright_owner','status'];
+        $allowed_filters = ['comments','artist','title','album','year','type','category','country','language','genre','duration','is_copyright_owner','status','dynamic_select'];
         $allowed_operators = [
             // deprecated
             'like',
@@ -1034,6 +1034,7 @@ class MediaModel extends OBFModel
             $column_array['duration'] = 'media.duration';
             $column_array['comments'] = 'media.comments';
             $column_array['is_copyright_owner'] = 'media.is_copyright_owner';
+            $column_array['dynamic_select'] = 'media.dynamic_select';
 
             $metadata_fields = $this->models->mediametadata('get_all');
             $metadata_defaults = [];

--- a/public/html/sidebar/advanced_search.html
+++ b/public/html/sidebar/advanced_search.html
@@ -22,7 +22,7 @@
                     Is Copyright Owner
                 </option>
                 <option value="status" data-compare="select" data-value="status" data-t>Status</option>
-                <option value="dynamic_select" data-compare="select" data-value="bool" data-t>Include in Dynamic Selections</option>
+                <option value="dynamic_select" data-compare="select" data-value="bool" data-t>Include in Dynamic Selections?</option>
             </select>
 
             <select id="advanced_search_text_compare" data-type="compare" data-name="text">

--- a/public/html/sidebar/advanced_search.html
+++ b/public/html/sidebar/advanced_search.html
@@ -22,6 +22,7 @@
                     Is Copyright Owner
                 </option>
                 <option value="status" data-compare="select" data-value="status" data-t>Status</option>
+                <option value="dynamic_select" data-compare="select" data-value="bool" data-t>Include in Dynamic Selections</option>
             </select>
 
             <select id="advanced_search_text_compare" data-type="compare" data-name="text">


### PR DESCRIPTION
## Summary
Adds "Include in Dynamic Selections" filter to Advanced Search.

Closes #183

## Changes
- **Frontend:** Added filter option to dropdown ([public/html/sidebar/advanced_search.html](cci:7://file:///Users/somasreeshanth/observer/public/html/sidebar/advanced_search.html:0:0-0:0))
- **Backend:** Added `dynamic_select` to allowed filters and column mapping ([classes/models/media_model.php](cci:7://file:///Users/somasreeshanth/observer/classes/models/media_model.php:0:0-0:0))

## Screenshots
<img width="1495" height="971" alt="observer1" src="https://github.com/user-attachments/assets/2c88c1a1-973e-4625-8b9e-c6da3ce69e8d" />
<img width="1497" height="880" alt="observer2" src="https://github.com/user-attachments/assets/53dfc94a-7600-4512-aaaf-716be3de7e4e" />
