### PR TITLE
feat(search): add date filters for created and updated fields in advanced search

### DIFF
--- a/core/models/media_model.php
+++ b/core/models/media_model.php
@@ -954,7 +954,7 @@ class MediaModel extends OBFModel
         OBFHelpers::require_args($args, ['filters']);
         $filters = $args['filters'];
 
-        $allowed_filters = ['id','comments','artist','title','album','year','type','format','category','country','language','genre','duration','is_copyright_owner','status','dynamic_select','owner','group'];
+        $allowed_filters = ['id','comments','artist','title','album','year','type','format','category','country','language','genre','duration','created','updated','is_copyright_owner','status','dynamic_select','owner','group'];
         $allowed_operators = [
             // deprecated
             'like',
@@ -1034,6 +1034,8 @@ class MediaModel extends OBFModel
             $column_array['language'] = 'media.language';
             $column_array['genre'] = 'media.genre_id';
             $column_array['duration'] = 'media.duration';
+            $column_array['created'] = 'media.created';
+            $column_array['updated'] = 'media.updated';
             $column_array['comments'] = 'media.comments';
             $column_array['is_copyright_owner'] = 'media.is_copyright_owner';
             $column_array['id'] = 'media.id';
@@ -1123,6 +1125,37 @@ class MediaModel extends OBFModel
                     $tmp_sql = 'COALESCE(' . $this->db->format_table_column($column_array[$filter['filter']]) . ',"' . $this->db->escape($default) . '")';
                 } else {
                     $tmp_sql = $column_array[$filter['filter']];
+                }
+
+                $is_date_filter = in_array($filter['filter'], ['created', 'updated'], true);
+                $date_value = null;
+                if ($is_date_filter && preg_match('/^\d{4}-\d{2}-\d{2}$/', (string) $filter['val'])) {
+                    $date_value = strtotime($filter['val'] . ' 00:00:00');
+                }
+
+                if ($is_date_filter && $date_value !== false && $date_value !== null) {
+                    $day_start = (int) $date_value;
+                    $day_end = $day_start + 86399;
+                    $column = $tmp_sql;
+
+                    if (in_array($filter['op'], ['is', 'eq'], true)) {
+                        $tmp_sql = '(' . $column . ' >= "' . $day_start . '" AND ' . $column . ' <= "' . $day_end . '")';
+                    } elseif (in_array($filter['op'], ['not', 'neq'], true)) {
+                        $tmp_sql = '(' . $column . ' < "' . $day_start . '" OR ' . $column . ' > "' . $day_end . '")';
+                    } elseif (in_array($filter['op'], ['gte', 'gt'], true)) {
+                        $compare_value = $filter['op'] == 'gt' ? $day_end : $day_start;
+                        $operator = $filter['op'] == 'gt' ? '>' : '>=';
+                        $tmp_sql = $column . ' ' . $operator . ' "' . $compare_value . '"';
+                    } elseif (in_array($filter['op'], ['lte', 'lt'], true)) {
+                        $compare_value = $filter['op'] == 'lt' ? $day_start : $day_end;
+                        $operator = $filter['op'] == 'lt' ? '<' : '<=';
+                        $tmp_sql = $column . ' ' . $operator . ' "' . $compare_value . '"';
+                    } else {
+                        $tmp_sql = $column . ' ' . $op_array[$filter['op']] . ' "' . $day_start . '"';
+                    }
+
+                    $where_array[] = $tmp_sql;
+                    continue;
                 }
 
                 $tmp_sql .= ' ' . $op_array[$filter['op']] . ' "';

--- a/public/html/sidebar/advanced_search.html
+++ b/public/html/sidebar/advanced_search.html
@@ -113,7 +113,7 @@
             </select>
 
             <input type="text" id="advanced_search_value" data-type="value" data-name="text" />
-            <input type="date" id="advanced_search_date_value" data-type="value" data-name="date" class="hidden" />
+            <ob-date-input id="advanced_search_date_value" data-type="value" data-name="date" class="hidden"></ob-date-input>
 
             <select id="advanced_search_owner_options" data-type="value" data-name="owner" class="hidden"></select>
 

--- a/public/html/sidebar/advanced_search.html
+++ b/public/html/sidebar/advanced_search.html
@@ -20,6 +20,8 @@
                 <option value="genre" data-compare="select" data-value="genre" data-t>Genre</option>
                 <option value="comments" data-compare="text" data-value="text" data-t>Comments</option>
                 <option value="duration" data-compare="duration" data-value="text" data-t>Duration</option>
+                <option value="created" data-compare="date" data-value="date" data-t>Created Date</option>
+                <option value="updated" data-compare="date" data-value="date" data-t>Last Updated Date</option>
                 <option value="is_copyright_owner" data-compare="select" data-value="bool" data-t>
                     Is Copyright Owner
                 </option>
@@ -51,6 +53,13 @@
             <select id="advanced_search_duration_compare" data-type="compare" data-name="duration" class="hidden">
                 <option value="gte">is greater than or equal to (seconds)</option>
                 <option value="lte">is less than or equal to (seconds)</option>
+            </select>
+
+            <select id="advanced_search_date_compare" data-type="compare" data-name="date" class="hidden">
+                <option value="is">is on</option>
+                <option value="not">is not on</option>
+                <option value="gte">is on or after</option>
+                <option value="lte">is on or before</option>
             </select>
 
             <select id="advanced_search_select_compare" data-type="compare" data-name="select" class="hidden">
@@ -104,6 +113,7 @@
             </select>
 
             <input type="text" id="advanced_search_value" data-type="value" data-name="text" />
+            <input type="date" id="advanced_search_date_value" data-type="value" data-name="date" class="hidden" />
 
             <select id="advanced_search_owner_options" data-type="value" data-name="owner" class="hidden"></select>
 

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -1506,6 +1506,11 @@ OB.Sidebar.advancedSearchAdd = function (filter_data) {
             return false;
         }
 
+        if ((filter == "created" || filter == "updated") && val.match(/^\d{4}-\d{2}-\d{2}$/) === null) {
+            $("#advanced_search_message").obWidget("error", ["A valid %1 is required", filter_name.toLowerCase()]);
+            return false;
+        }
+
         $("#advanced_search_no_criteria").hide();
         OB.Sidebar.advanced_search_filter_id++;
 
@@ -1513,6 +1518,7 @@ OB.Sidebar.advancedSearchAdd = function (filter_data) {
 
         if (compare_field == "select") filter_description += " " + op_name + " " + val_name;
         else if (compare_field == "number") filter_description += " " + op_name + " " + val;
+        else if (compare_field == "date") filter_description += " " + op_name + " " + val;
         //T seconds
         else if (compare_field == "duration") filter_description += " " + op_name + " " + val + " " + OB.t("seconds");
         else filter_description += " " + op_name + ' "' + val + '"';

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -1487,13 +1487,17 @@ OB.Sidebar.advancedSearchAdd = function (filter_data) {
         var op_name = $op.text();
 
         var $val = $(".advanced_search [data-type=value][data-name=" + value_field + "]");
-        var val = $val.val();
+        if ($val.prop("nodeName") == "OB-DATE-INPUT") {
+            var val = OB.UI.dateInputVal($val[0]);
+        } else {
+            var val = $val.val();
+        }
         if ($val.prop("nodeName") == "SELECT") var val_name = $val.find("option:selected").text();
         else if ($val.prop("nodeName") == "OB-FIELD-LANGUAGE") var val_name = $val[0].currentLanguageName();
         else if ($val.prop("nodeName") == "OB-FIELD-COUNTRY") var val_name = $val[0].currentCountryName();
 
         // trim val
-        val = val.trim();
+        if (typeof val === "string") val = val.trim();
 
         // some basic validation
         if ((filter == "artist" || filter == "album" || filter == "title") && val == "") {
@@ -1506,7 +1510,7 @@ OB.Sidebar.advancedSearchAdd = function (filter_data) {
             return false;
         }
 
-        if ((filter == "created" || filter == "updated") && val.match(/^\d{4}-\d{2}-\d{2}$/) === null) {
+        if ((filter == "created" || filter == "updated") && (!val || val === "")) {
             $("#advanced_search_message").obWidget("error", ["A valid %1 is required", filter_name.toLowerCase()]);
             return false;
         }


### PR DESCRIPTION
Closes #80

## Summary
Adds date-based advanced search filters for media in the sidebar, with support for both **Created Date** and **Last Updated Date**.

## Changes

### Backend
`core/models/media_model.php`
- Added `created` and `updated` to allowed advanced-search filters.
- Added SQL column mapping for:
  - `created -> media.created`
  - `updated -> media.updated`
- Added day-aware date comparison handling for advanced filters:
  - `is` / `eq`: matches records within that full day
  - `not` / `neq`: excludes that full day
  - `gte` / `lte` / `gt` / `lt`: compares using day boundaries
- Preserves existing operator behavior for non-date filters.

### Frontend
`public/html/sidebar/advanced_search.html`
- Added new filter options:
  - `Created Date`
  - `Last Updated Date`
- Added date operator dropdown:
  - `is on`
  - `is not on`
  - `is on or after`
  - `is on or before`
- Added date input field (`type="date"`) for date filters.

`public/js/sidebar.js`
- Added validation for date filter values (`YYYY-MM-DD`).
- Added date filter description rendering in criteria list.

## Behavior
- Advanced Search now supports filtering media by:
  - **Created Date**
  - **Last Updated Date**
- Date comparisons operate on full calendar days (not raw timestamp equality).
- Existing simple search and non-date advanced filters are unchanged.

## Verification
- [x] Open Sidebar -> Media -> Advanced Search.
- [x] Select `Created Date`, choose each operator (`is on`, `is not on`, `is on or after`, `is on or before`), set a date, and run search.
- [x] Repeat with `Last Updated Date`.
- [x] Confirm criteria chips/descriptions appear correctly and results match expected date-based behavior.
- [x] Confirm no regressions for existing advanced filters (artist/title/year/duration/etc.).

<img width="1660" height="816" alt="image" src="https://github.com/user-attachments/assets/06727e81-7ca0-42b2-9185-d0db22964039" />
<img width="1678" height="788" alt="image" src="https://github.com/user-attachments/assets/5503321c-d525-42d9-b95c-6b5fc97f03bc" />
<img width="2504" height="1340" alt="image" src="https://github.com/user-attachments/assets/9d9473bd-8aa9-406b-a4fb-bc4624ef149b" />

