### PR TITLE
feat(search): Implement 'Copyright Owner' filter in advanced search by joinin…

### DIFF
--- a/core/models/media_model.php
+++ b/core/models/media_model.php
@@ -830,6 +830,7 @@ class MediaModel extends OBFModel
         $this->db->leftjoin('media_categories', 'media.category_id', 'media_categories.id');
         $this->db->leftjoin('countries', 'media.country', 'countries.country_id');
         $this->db->leftjoin('languages', 'media.language', 'languages.language_id');
+        $this->db->leftjoin('users', 'media.owner_id', 'users.id');
 
         if ($params['sort_by'] == 'category_name') {
             $params['sort_by'] = 'media_categories.name';
@@ -954,7 +955,7 @@ class MediaModel extends OBFModel
         OBFHelpers::require_args($args, ['filters']);
         $filters = $args['filters'];
 
-        $allowed_filters = ['comments','artist','title','album','year','type','category','country','language','genre','duration','is_copyright_owner','status','dynamic_select'];
+        $allowed_filters = ['comments','artist','title','album','year','type','category','country','language','genre','duration','is_copyright_owner','copyright_owner','status','dynamic_select'];
         $allowed_operators = [
             // deprecated
             'like',
@@ -1036,6 +1037,7 @@ class MediaModel extends OBFModel
             $column_array['duration'] = 'media.duration';
             $column_array['comments'] = 'media.comments';
             $column_array['is_copyright_owner'] = 'media.is_copyright_owner';
+            $column_array['copyright_owner'] = 'users.username';
             $column_array['dynamic_select'] = 'media.dynamic_select';
 
             $metadata_fields = $this->models->mediametadata('get_all');
@@ -1125,6 +1127,11 @@ class MediaModel extends OBFModel
             }
 
             $where_array[] = $tmp_sql;
+
+            // copyright_owner filter: also enforce that is_copyright_owner = 1
+            if ($filter['filter'] == 'copyright_owner') {
+                $where_array[] = 'media.is_copyright_owner = 1';
+            }
         }
 
         return $where_array;

--- a/public/html/sidebar/advanced_search.html
+++ b/public/html/sidebar/advanced_search.html
@@ -21,6 +21,7 @@
                 <option value="is_copyright_owner" data-compare="select" data-value="bool" data-t>
                     Is Copyright Owner
                 </option>
+                <option value="copyright_owner" data-compare="text" data-value="text" data-t>Copyright Owner</option>
                 <option value="status" data-compare="select" data-value="status" data-t>Status</option>
                 <option value="dynamic_select" data-compare="select" data-value="bool" data-t>Include in Dynamic Selections?</option>
             </select>


### PR DESCRIPTION
Closes #130

## Summary

Adds a **"Copyright Owner"** filter to Advanced Search, allowing users to search media by the username of the user who claimed copyright ownership.

This enables searching for media owned and explicitly marked as copyrighted by a specific user.

---

## Changes

### Backend  
**File:** `core/models/media_model.php`

- Added `copyright_owner` to `$allowed_filters` in advanced search validation.
- Added column mapping:
  - `copyright_owner` → `users.username`
- Added:
  ```php
  LEFT JOIN users ON media.owner_id = users.id
  ```
  in `search()` to allow filtering by user data.
- When the `copyright_owner` filter is applied, automatically enforces:
  ```sql
  media.is_copyright_owner = 1
  ```
- Preserves all existing behavior for other filters and operators.

---

### Frontend  
**File:** `public/html/sidebar/advanced_search.html`

- Added new filter option:
  - **Copyright Owner**
- Uses standard text operators:
  - `contains`
  - `does not contain`
  - `is exactly`
  - `is not`
- Uses a standard text input field for the user name.

---

## Behavior

Advanced Search now supports filtering media by:

- **Copyright Owner (username)**

The filter matches:

```sql
users.username LIKE ...
AND media.is_copyright_owner = 1
```

Other search functionality (simple search and existing advanced filters) remains unchanged.

---

## Verification Steps

- [x] Open **Sidebar → Media → Advanced Search**
- [x] Select **Copyright Owner**
- [x] Test each operator:
  - contains
  - does not contain
  - is exactly
  - is not
- [x] Enter a valid username and run search
- [x] Confirm the criteria description renders correctly
- [x] Confirm results only include media where:
  - The matching user is the owner
  - `is_copyright_owner = 1`
- [x] Confirm no regressions for existing filters (artist, title, year, duration, etc.)

<img width="2484" height="1296" alt="image" src="https://github.com/user-attachments/assets/50624ce8-7a51-4274-ab0f-1c51c81c4f07" />
<img width="2484" height="1288" alt="image" src="https://github.com/user-attachments/assets/50a97795-698c-4dcb-92f7-01668799f14e" />
