### PR TITLE
feat(search): Implement 'never_broadcasted' filter for media search and add i…

### DIFF
--- a/core/models/media_model.php
+++ b/core/models/media_model.php
@@ -954,7 +954,7 @@ class MediaModel extends OBFModel
         OBFHelpers::require_args($args, ['filters']);
         $filters = $args['filters'];
 
-        $allowed_filters = ['comments','artist','title','album','year','type','category','country','language','genre','duration','is_copyright_owner','status','dynamic_select'];
+        $allowed_filters = ['comments','artist','title','album','year','type','category','country','language','genre','duration','is_copyright_owner','never_broadcasted','status','dynamic_select'];
         $allowed_operators = [
             // deprecated
             'like',
@@ -1019,6 +1019,16 @@ class MediaModel extends OBFModel
         foreach ($filters as $filter) {
             if (is_object($filter)) {
                 $filter = get_object_vars($filter);
+            }
+
+            // never_broadcasted filter: uses subquery, skip normal column mapping
+            if ($filter['filter'] == 'never_broadcasted') {
+                if ($filter['val'] == '1') {
+                    $where_array[] = 'NOT EXISTS (SELECT 1 FROM players_log WHERE players_log.media_id = media.id)';
+                } else {
+                    $where_array[] = 'EXISTS (SELECT 1 FROM players_log WHERE players_log.media_id = media.id)';
+                }
+                continue;
             }
 
             // our possible column (mappings)

--- a/public/html/sidebar/advanced_search.html
+++ b/public/html/sidebar/advanced_search.html
@@ -21,6 +21,7 @@
                 <option value="is_copyright_owner" data-compare="select" data-value="bool" data-t>
                     Is Copyright Owner
                 </option>
+                <option value="never_broadcasted" data-compare="select" data-value="bool" data-t>Never Been Broadcast</option>
                 <option value="status" data-compare="select" data-value="status" data-t>Status</option>
                 <option value="dynamic_select" data-compare="select" data-value="bool" data-t>Include in Dynamic Selections?</option>
             </select>


### PR DESCRIPTION
**Closes:** #185

### Summary

Adds a new **"Never Been Broadcast"** boolean filter to Advanced Search, allowing users to find media that has never been played by any player. Designed to help narrow down material hidden in the archive and to support dynamic sections for unplayed content.

### Problem

In large databases (e.g., CJUC with 166K+ media items), an estimated 20–30% of media has never been played. There was no way to search for or identify this unplayed content.

### Changes

#### Backend — [core/models/media_model.php](file:///Users/somasreeshanth/observer/core/models/media_model.php)

- Added `'never_broadcasted'` to `$allowed_filters` in [search_filters_validate()](file:///Users/somasreeshanth/observer/core/models/media_model.php#944-1004)
- Added special handling in [search_filters_where_array()](file:///Users/somasreeshanth/observer/core/models/media_model.php#1005-1132) that bypasses normal column mapping and uses a correlated subquery:
  - **Yes (value=1):** `NOT EXISTS (SELECT 1 FROM players_log WHERE players_log.media_id = media.id)`
  - **No (value=0):** `EXISTS (SELECT 1 FROM players_log WHERE players_log.media_id = media.id)`

#### Frontend — [public/html/sidebar/advanced_search.html](file:///Users/somasreeshanth/observer/public/html/sidebar/advanced_search.html)

- Added `<option value="never_broadcasted" ...>Never Been Broadcast</option>` as a boolean filter (Yes/No)

### Performance

Uses `NOT EXISTS` with a correlated subquery — the most efficient SQL pattern for this use case:

- **Short-circuits** on the first matching row (doesn't scan entire `players_log`)
- **No duplicates** (unlike `LEFT JOIN` which multiplies rows for media broadcast multiple times)
- **No aggregation** (unlike `COUNT(*)` / `HAVING` approaches)
- `players_log.media_id` is already indexed (`MUL` key), so lookups are O(log n)
- Search results are paginated via `LIMIT`/`OFFSET`, so only one page is returned at a time

Expected query time at 170K items: **sub-second** (~50–200ms with index).

### Verification

- [x] Created a test player and inserted a `players_log` entry for one media item to simulate a broadcast
- [x] **"Never Been Broadcast" = Yes** → returned 3 results (media without any broadcast log)
- [x] **"Never Been Broadcast" = No** → returned remaining media that has been broadcast
- [x] Existing filters (Artist, Status, etc.) continue to work correctly

<img width="2486" height="1288" alt="image" src="https://github.com/user-attachments/assets/691ef5b4-3375-4bb0-9e5b-06716616dc3b" />
<img width="2482" height="1288" alt="image" src="https://github.com/user-attachments/assets/a5daabd1-da50-4ca3-bec2-9e53703835f6" />
