### PR TITLE
fix(search): advanced search now ORs same-column filters

### DIFF
--- a/core/models/media_model.php
+++ b/core/models/media_model.php
@@ -1015,46 +1015,47 @@ class MediaModel extends OBFModel
         $filters = $args['filters'];
 
         $where_array = [];
+        $grouped_filters = [];
+
+        // our possible column (mappings)
+        $column_array = [];
+        $column_array['artist'] = 'media.artist';
+        $column_array['title'] = 'media.title';
+        $column_array['album'] = 'media.album';
+        $column_array['year'] = 'media.year';
+        $column_array['type'] = 'media.type';
+        $column_array['status'] = 'media.status';
+        $column_array['category'] = 'media.category_id';
+        $column_array['country'] = 'media.country';
+        $column_array['language'] = 'media.language';
+        $column_array['genre'] = 'media.genre_id';
+        $column_array['duration'] = 'media.duration';
+        $column_array['comments'] = 'media.comments';
+        $column_array['is_copyright_owner'] = 'media.is_copyright_owner';
+        $column_array['dynamic_select'] = 'media.dynamic_select';
+
+        $metadata_fields = $this->models->mediametadata('get_all');
+        $metadata_defaults = [];
+        foreach ($metadata_fields as $metadata_field) {
+            $column_array['metadata_' . $metadata_field['name']] = 'media.metadata_' . $metadata_field['name'];
+            if (isset($metadata_field['settings']->default)) {
+                $default = $metadata_field['settings']->default;
+
+                // make lowercase for case insensitive comparison
+                if (is_array($default)) {
+                    $default = array_map('strtolower', $default);
+                } else {
+                    $default = strtolower($default);
+                }
+
+                // keep track for comparison below
+                $metadata_defaults['metadata_' . $metadata_field['name']] = $default;
+            }
+        }
 
         foreach ($filters as $filter) {
             if (is_object($filter)) {
                 $filter = get_object_vars($filter);
-            }
-
-            // our possible column (mappings)
-            $column_array = [];
-            $column_array['artist'] = 'media.artist';
-            $column_array['title'] = 'media.title';
-            $column_array['album'] = 'media.album';
-            $column_array['year'] = 'media.year';
-            $column_array['type'] = 'media.type';
-            $column_array['status'] = 'media.status';
-            $column_array['category'] = 'media.category_id';
-            $column_array['country'] = 'media.country';
-            $column_array['language'] = 'media.language';
-            $column_array['genre'] = 'media.genre_id';
-            $column_array['duration'] = 'media.duration';
-            $column_array['comments'] = 'media.comments';
-            $column_array['is_copyright_owner'] = 'media.is_copyright_owner';
-            $column_array['dynamic_select'] = 'media.dynamic_select';
-
-            $metadata_fields = $this->models->mediametadata('get_all');
-            $metadata_defaults = [];
-            foreach ($metadata_fields as $metadata_field) {
-                $column_array['metadata_' . $metadata_field['name']] = 'media.metadata_' . $metadata_field['name'];
-                if (isset($metadata_field['settings']->default)) {
-                    $default = $metadata_field['settings']->default;
-
-                    // make lowercase for case insensitive comparison
-                    if (is_array($default)) {
-                        $default = array_map('strtolower', $default);
-                    } else {
-                        $default = strtolower($default);
-                    }
-
-                    // keep track for comparison below
-                    $metadata_defaults['metadata_' . $metadata_field['name']] = $default;
-                }
             }
 
             // find_in_set works a bit differently
@@ -1124,7 +1125,21 @@ class MediaModel extends OBFModel
                 $tmp_sql .= '"';
             }
 
-            $where_array[] = $tmp_sql;
+            // Group by SQL column so same-column filters can be OR'd.
+            $group_key = $column_array[$filter['filter']];
+            if (!isset($grouped_filters[$group_key])) {
+                $grouped_filters[$group_key] = [];
+            }
+            $grouped_filters[$group_key][] = $tmp_sql;
+        }
+
+        // Same-column filters are OR'd, different columns stay AND'd by caller.
+        foreach ($grouped_filters as $conditions) {
+            if (count($conditions) === 1) {
+                $where_array[] = $conditions[0];
+            } else {
+                $where_array[] = '(' . implode(' OR ', $conditions) . ')';
+            }
         }
 
         return $where_array;


### PR DESCRIPTION
**Closes:** #129

### Summary

Fixes Advanced Search logic so multiple values for the same field are OR-grouped, while different fields remain AND-combined.

This makes queries behave as expected:

```sql
(genre = Action OR genre = ComedyFunny)
AND type = …
AND additional filters
```

### Problem

`search_filters_where_array()` previously built a flat list of SQL conditions, and the caller joined everything with `AND`.  

So selecting two genres produced:
`genre_id = "1" AND genre_id = "2"`

which can never match a single row, causing zero results.

### Changes

#### Backend — `core/models/media_model.php`

- Updated `search_filters_where_array()` to:
  - Build each filter SQL condition as before.
  - Group conditions by resolved SQL column name (after metadata/alias resolution)
  - OR conditions inside each same-column group.
  - Return grouped clauses for existing outer `AND` join behavior.
- Kept all existing operator/default handling intact (`eq`, `contains`, `has`, metadata defaults, etc.).
- Hoisted metadata/column mapping setup outside the per-filter loop for better efficiency.

### Verification Steps
- [x] Open `Sidebar → Media → Advanced Search`.
- [x] Add filter: `Genre` `is` `Action`, click `Add`.
- [x] Add filter: `Genre` `is` `ComedyFunny`, click `Add`.
- [x] Add filter: `Include in Dynamic Selections?` `is` `Yes`, click `Add`.
- [x] Click `Search`.
- [x] Confirm results match:
      (Genre = Action OR Genre = ComedyFunny)
      AND Include in Dynamic Selections = Yes.

<img width="1256" height="484" alt="image" src="https://github.com/user-attachments/assets/24b8286e-9dca-471d-a12e-6564b1d83a72" />
<img width="2492" height="1282" alt="image" src="https://github.com/user-attachments/assets/a294ed04-bda8-435d-828b-df896601f60d" />
<img width="2478" height="1294" alt="image" src="https://github.com/user-attachments/assets/5ef4a37a-1594-4e38-a87b-4e587b406537" />


