### PR TITLE
fix: patch upload.php and media_model.php for k6 load testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ vendor
 node_modules
 .php-cs-fixer.cache
 bundles
+media_data/
+.DS_Store

--- a/core/models/Media.php
+++ b/core/models/Media.php
@@ -1932,7 +1932,7 @@ class Media extends Model
             }
 
             // move our file to its home
-            $file_src = OB_UPLOADS . '/' . $file_id;
+            $file_src = OB_MEDIA_UPLOADS . '/' . $file_id;
 
             if ($item['is_approved'] == 0) {
                 $file_dest = OB_MEDIA_UNAPPROVED . $media_location . $filename;
@@ -2175,7 +2175,7 @@ class Media extends Model
         }
 
         // move file
-        if (!rename(OB_UPLOADS . '/' . $file_id, $dst_file)) {
+        if (!rename(OB_MEDIA_UPLOADS . '/' . $file_id, $dst_file)) {
             return [false, 'Error adding new version.'];
         }
 
@@ -2803,7 +2803,7 @@ class Media extends Model
 
         foreach ($requiredDirs as $checkDir) {
             if (!file_exists($checkDir)) {
-                mkdir($checkDir);
+                mkdir($checkDir, 0755, true);
             }
         }
 

--- a/public/upload.php
+++ b/public/upload.php
@@ -5,6 +5,8 @@
 
 require_once(__DIR__ . '/../core/init.php');
 
+use OpenBroadcaster\Base\Controller;
+
 // COMPLETE AUTHENTICATION, usually handled by api.php
 $user = OBFUser::get_instance();
 
@@ -35,7 +37,7 @@ if (empty($_POST['appkey'])) {
 }
 
 // define our class, create instance, handle upload.
-class Upload extends OBFController
+class Upload extends Controller
 {
     // used by handle_upload() to get some important information about the uploaded media
     private function media_info($filename)
@@ -57,14 +59,14 @@ class Upload extends OBFController
         $id = $this->db->insert('uploads', ['key' => $key, 'expiry' => strtotime('+24 hours')]);
 
         $input = fopen("php://input", "r");
-        $target = fopen(OB_UPLOADS . '/' . $id, "w");
+        $target = fopen(OB_MEDIA_UPLOADS . '/' . $id, "w");
         $realSize = stream_copy_to_stream($input, $target);
         fclose($input);
         fclose($target);
 
         if ($realSize != (int) $_SERVER["CONTENT_LENGTH"]) {
             echo json_encode(['error' => 'File upload was not successful.  Please try again.']);
-            unlink(OB_UPLOADS . '/' . $id);
+            unlink(OB_MEDIA_UPLOADS . '/' . $id);
             return;
         }
 
@@ -75,7 +77,7 @@ class Upload extends OBFController
             } else {
                 echo json_encode(['error' => 'File too large (max size ' . OB_MEDIA_FILESIZE_LIMIT . 'MB).']);
             }
-            unlink(OB_UPLOADS . '/' . $id);
+            unlink(OB_MEDIA_UPLOADS . '/' . $id);
             return;
         }
 
@@ -83,7 +85,7 @@ class Upload extends OBFController
         $result['file_key'] = $key;
 
         // get ID3 data.
-        $id3_data = $models->media('getid3', ['filename' => OB_UPLOADS . '/' . $id]);
+        $id3_data = $models->media('getid3', ['filename' => OB_MEDIA_UPLOADS . '/' . $id]);
         if (count($id3_data) > 0) {
             $result['info'] = ['comments' => $id3_data];
         } else {
@@ -91,7 +93,7 @@ class Upload extends OBFController
         }
 
         // get some useful media information, insert it into the db with our file id/key.
-        $media_info = $this->media_info(OB_UPLOADS . '/' . $id);
+        $media_info = $this->media_info(OB_MEDIA_UPLOADS . '/' . $id);
         $this->db->where('id', $id);
         $this->db->update('uploads', ['format' => $media_info['format'], 'type' => $media_info['type'], 'duration' => $media_info['duration']]);
 


### PR DESCRIPTION
Found these while building the k6 load testing tool, the upload/media save pipeline has a few references that haven't been updated yet in the 5.5 refactor: 

### **public/upload.php:** 
- `OBFController` → `OpenBroadcaster\Base\Controller` (class was renamed) 
- `OB_UPLOADS` → `OB_MEDIA_UPLOADS` (constant renamed, 5 occurrences) 

### **core/models/media_model.php:** 
- `OB_UPLOADS` → `OB_MEDIA_UPLOADS` (lines 1935, 2178) 
- `mkdir($checkDir)` → `mkdir($checkDir, 0755, true)` (line 2806 — the other 3 mkdir calls in the same file already use recursive, this one was missed) 

These are needed for the k6 load testing tool to exercise the upload/media save pipeline.