### PR TITLE
Add media details monitoring shortcut

### DIFF
--- a/public/html/media/details.html
+++ b/public/html/media/details.html
@@ -51,6 +51,15 @@
                         class="hidden"
                         >Versions</ob-element-button
                     >
+                    <ob-element-button
+                        data-text="Monitoring"
+                        data-icon-name="chart-line"
+                        data-icon-style="solid"
+                        data-t
+                        id="media_details_monitoring"
+                        class="hidden"
+                        >Monitoring</ob-element-button
+                    >
                 </p>
             </div>
             <ob-field-thumbnail

--- a/public/js/media/details.js
+++ b/public/js/media/details.js
@@ -79,6 +79,17 @@ OB.MediaDetails.page = function (id) {
             document.querySelector("#media_details_restore").classList.remove("hidden");
         }
 
+        // allow users with player monitoring access to jump directly to filtered monitoring results.
+        if (
+            OB.Settings.permissions.indexOf("view_player_monitor") != -1 ||
+            OB.Settings.permissions.some((permission) => permission.indexOf("view_player_monitor:") == 0)
+        ) {
+            $("#media_details_monitoring").click(function () {
+                OB.Player.monitor({ media_id: id });
+            });
+            document.querySelector("#media_details_monitoring").classList.remove("hidden");
+        }
+
         // handle metadata
         $("#media_details_id").text(id);
         $("#media_details_thumbnail").val(item.thumbnail);

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -297,7 +297,7 @@ OB.Player.deletePlayerConfirm = function (player_id) {
    PLAYER MONITORING SECTION
 ========================= */
 
-OB.Player.monitor = function () {
+OB.Player.monitor = function (options = {}) {
     OB.UI.replaceMain("player/monitor.html");
 
     $("#monitor_date_start").attr("data-value", moment().subtract(1, "days"));
@@ -316,6 +316,15 @@ OB.Player.monitor = function () {
                 '<option value="' + item.id + '">' + htmlspecialchars(item.name) + "</option>",
             );
         });
+
+        if (options.media_id) {
+            $("#monitor_filter_field").val("media_id");
+            OB.Player.monitorFilterFieldChange();
+            $("#monitor_filter_operator").val("is");
+            $("#monitor_filter_value").val(options.media_id);
+            OB.Player.monitorFilterAdd();
+            OB.Player.monitorSearch();
+        }
     });
 };
 


### PR DESCRIPTION
## Summary
- Adds a Monitoring action to media details for users with player-monitoring permission.
- Opens Player Monitoring with a Media ID filter prefilled for the current media item.
- Automatically loads the filtered monitoring results after the available player list is populated.

Fixes #191

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- `node --check public/js/media/details.js`
- `node --check public/js/player.js`
- `git diff --check`

## Testing Environments
OpenBroadcaster Component and Version
- [x] OBServer

## Browser Version?
- [x] Chrome

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] My changes generate no new warnings

Thanks for contributing!