### PR TITLE
Fix namespace issue in Update20240731.php

### DIFF
--- a/core/updates/Update20240731.php
+++ b/core/updates/Update20240731.php
@@ -37,7 +37,7 @@ class Update20240731 extends Update
             mkdir(OB_THUMBNAILS . '/media', 0777, true);
         }
 
-        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(OB_THUMBNAILS . '/media'));
+        $rii = new RecursiveIteratorIterator(new \RecursiveDirectoryIterator(OB_THUMBNAILS . '/media'));
         $thumbnails = [];
         foreach ($rii as $file) {
             if ($file->isDir()) {


### PR DESCRIPTION
RecursiveIteratorIterator/RecursiveDirectoryIterator were being resolved inside the OpenBroadcatser\Updates namespace instead of PHP's global SPL classes.  This was preventing the update chain, and observer was showing "update required" on localhost:8080/welcome.

# OB Description

Added a blackslash

**IMPORTANT: Search previous suggestions before making a new one, as yours may be a duplicate. Do not create a Pull Request without creating an issue first.

## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
- [ ] This change requires a documentation update 

## How Has This Been Tested?
Tested in my containerized fresh build of OBServer.

## Testing Environments
OpenBroadcaster Component  and Version
- [ X] OBServer 
- [ ] OBPlayer 
- [ ] Module
- [ ] Other

## Browser Version?
- [ X] Chrome
- [ ] Edge\IE
- [ ] Firefox
- [ ] Safari
- [ ] Other

## OS Version?
- [ ] BSD
- [ ] Debian
- [ ] Raspberry OS
- [X ] Ubuntu (24.04)
- [ ] Other

## Checklist:
- [X ] My code follows the style guidelines of this project 
- [X ] I have performed a self-review of my own code and corrected any misspellings
- [X ] I have commented my code, particularly in hard-to-understand areas 
- [ X] I have made corresponding changes to the documentation 
- [ X] My changes generate no new warnings 
- [ X] I have added tests that prove my fix is effective or that my feature works 
- [ X] New and existing unit tests pass locally with my changes

Thanks for contributing!
